### PR TITLE
build: download all artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     name: Deploy to S3
     runs-on: ubuntu-latest
     needs: main
-    if: github.ref == 'refs/heads/main'
+    # if: github.ref == 'refs/heads/main'
     environment:
       name: production
       url: https://vendittelli.co.uk
@@ -76,11 +76,8 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Download dist artifact
+      - name: Download all artifacts
         uses: actions/download-artifact@v3
-        with:
-          name: dist
-          path: dist
 
       - name: Configure AWS credentials for deployments
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     name: Deploy to S3
     runs-on: ubuntu-latest
     needs: main
-    # if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     environment:
       name: production
       url: https://vendittelli.co.uk


### PR DESCRIPTION
To circumvent the issue of no dist artifact being created for some runs, download all the artifacts.