### PR TITLE
chore(aws): remove old deployments from S3

### DIFF
--- a/apps/home/project.json
+++ b/apps/home/project.json
@@ -80,7 +80,7 @@
       "executor": "nx:run-commands",
       "outputs": [],
       "options": {
-        "command": "aws s3 sync dist/apps/home s3://vendittelli.co.uk"
+        "command": "aws s3 sync dist/apps/home s3://vendittelli.co.uk --delete"
       }
     }
   },


### PR DESCRIPTION
When deploying a new version of the site, delete files that are no longer required. Without this, old versions of the files would remain in the S3 bucket indefinitely.