### PR TITLE
ci(home): make deploy depend on build

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "conventionalCommits.scopes": ["home"]
+}

--- a/apps/home/project.json
+++ b/apps/home/project.json
@@ -86,6 +86,7 @@
     },
     "deploy": {
       "executor": "nx:run-commands",
+      "dependsOn": ["build"],
       "options": {
         "command": "aws s3 sync dist/apps/home s3://vendittelli.co.uk --delete"
       }


### PR DESCRIPTION
Ensure that build has always run before we attempt a deployment.