### PR TITLE
chore(security): set HSTS max-age to 5 minutes

### DIFF
--- a/terraform/cloudflare.tf
+++ b/terraform/cloudflare.tf
@@ -72,6 +72,7 @@ resource "cloudflare_zone_settings_override" "security" {
     tls_1_3                  = "on"
     security_header {
       enabled            = true
+      max_age            = 300
       include_subdomains = true
       preload            = false
     }


### PR DESCRIPTION
Increase the max-age for the Strict-Transport-Security header to 5 minutes.

#43