### PR TITLE
chore(security): set HSTS max-age to 1 week

### DIFF
--- a/terraform/cloudflare.tf
+++ b/terraform/cloudflare.tf
@@ -72,7 +72,7 @@ resource "cloudflare_zone_settings_override" "security" {
     tls_1_3                  = "on"
     security_header {
       enabled            = true
-      max_age            = 300
+      max_age            = 604800
       include_subdomains = true
       preload            = false
     }


### PR DESCRIPTION
Increase the max-age for the Strict-Transport-Security header to 1 week (604800).

#44