### PR TITLE
chore(security): add security headers

### DIFF
--- a/terraform/cloudflare.tf
+++ b/terraform/cloudflare.tf
@@ -78,3 +78,13 @@ resource "cloudflare_zone_settings_override" "security" {
     }
   }
 }
+
+# Enable security headers using Managed Meaders
+resource "cloudflare_managed_headers" "managed_headers" {
+  zone_id = local.zone_id
+
+  managed_response_headers {
+    id      = "add_security_headers"
+    enabled = true
+  }
+}


### PR DESCRIPTION
Adds the following headers:

- `X-Content-Type-Options: nosniff`
- `X-XSS-Protection: 1; mode=block`
- `X-Frame-Options: SAMEORIGIN`
- `Referrer-Policy: same-origin`
- `Expect-CT: max-age=86400, enforce`

Closes: #48