### PR TITLE
chore(security): increase minimum TLS version

### DIFF
--- a/terraform/cloudflare.tf
+++ b/terraform/cloudflare.tf
@@ -68,6 +68,7 @@ resource "cloudflare_zone_settings_override" "security" {
   settings {
     always_use_https         = "on"
     automatic_https_rewrites = "on"
+    min_tls_version          = "1.2"
     ssl                      = "flexible"
     tls_1_3                  = "on"
     security_header {


### PR DESCRIPTION
All browser support TLS 1.2 and most have dropped support for 1.0 and
1.1. Modern security standards require not supporting them.

Closes #53