### PR TITLE
chore(cloudflare): set HSTS max-age to 1 month

### DIFF
--- a/terraform/cloudflare.tf
+++ b/terraform/cloudflare.tf
@@ -86,7 +86,7 @@ resource "cloudflare_zone_settings_override" "security" {
     tls_1_3                  = "on"
     security_header {
       enabled            = true
-      max_age            = 604800
+      max_age            = 2592000
       include_subdomains = true
       preload            = false
     }


### PR DESCRIPTION
Increase the max-age for the Strict-Transport-Security header to 1 month (2592000).

closes #45
