### PR TITLE
chore(deps): group terraform dependencies together

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,6 +15,11 @@
       "matchPackagePatterns": ["*"],
       "excludePackagePatterns": ["github-pages"],
       "enabled": false
+    },
+    {
+      "description": "Group all terraform dependencies together",
+      "matchManagers": ["terraform"],
+      "groupName": "terraform"
     }
   ]
 }


### PR DESCRIPTION
To reduce the PR spam from terraform dependencies, group them all together. They cannot be automatically merged as they also require updating the readme, which is a manual process.